### PR TITLE
karaf-service should return 0 on start when service is already running

### DIFF
--- a/wrapper/src/main/resources/org/apache/karaf/wrapper/internal/unix/karaf-service
+++ b/wrapper/src/main/resources/org/apache/karaf/wrapper/internal/unix/karaf-service
@@ -422,7 +422,7 @@ start() {
         exec $COMMAND_LINE
     else
         echo "$APP_LONG_NAME is already running."
-        exit 1
+        exit 0
     fi
 }
 


### PR DESCRIPTION
from: http://refspecs.linuxbase.org/LSB_3.1.1/LSB-Core-generic/LSB-Core-generic/iniscrptact.html
... In addition to straightforward success, the following situations are also to be considered successful:
...
- running start on a service already running
  ...
